### PR TITLE
Add elementary tests to tag and untag

### DIFF
--- a/src/main/java/seedu/address/logic/commands/TagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TagCommand.java
@@ -104,4 +104,26 @@ public class TagCommand extends Command {
 
     }
 
+    public ContactIndex getIndex() {
+        return this.index;
+    }
+
+    public Set<ModuleTag> getModules() {
+        return this.moduleTags;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if (other instanceof TagCommand) {
+            TagCommand otherCommand = (TagCommand) other;
+            return otherCommand.getIndex().equals(getIndex())
+                    && otherCommand.getModules().equals(getModules());
+        } else {
+            return false;
+        }
+    }
+
 }

--- a/src/main/java/seedu/address/logic/commands/TagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TagCommand.java
@@ -121,9 +121,9 @@ public class TagCommand extends Command {
             TagCommand otherCommand = (TagCommand) other;
             return otherCommand.getIndex().equals(getIndex())
                     && otherCommand.getModules().equals(getModules());
-        } else {
-            return false;
         }
+
+        return false;
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/UntagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UntagCommand.java
@@ -101,5 +101,25 @@ public class UntagCommand extends Command {
                 + "Modules: " + editedUser.getImmutableModuleTags().toString()));
     }
 
+    public ContactIndex getIndex() {
+        return this.index;
+    }
 
+    public Set<ModuleTag> getModules() {
+        return this.moduleTags;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if (other instanceof UntagCommand) {
+            UntagCommand otherCommand = (UntagCommand) other;
+            return otherCommand.getIndex().equals(getIndex())
+                    && otherCommand.getModules().equals(getModules());
+        } else {
+            return false;
+        }
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/UntagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UntagCommand.java
@@ -118,8 +118,8 @@ public class UntagCommand extends Command {
             UntagCommand otherCommand = (UntagCommand) other;
             return otherCommand.getIndex().equals(getIndex())
                     && otherCommand.getModules().equals(getModules());
-        } else {
-            return false;
         }
+        return false;
+
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewCommand.java
@@ -85,8 +85,8 @@ public class ViewCommand extends Command {
             ViewCommand otherCommand = (ViewCommand) other;
             return otherCommand.getIndex().equals(getIndex())
                     && otherCommand.getName().equals(getName());
-        } else {
-            return false;
         }
+        return false;
+
     }
 }

--- a/src/main/java/seedu/address/logic/parser/UntagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UntagCommandParser.java
@@ -14,7 +14,7 @@ import seedu.address.model.tag.ModuleTag;
 /**
  * Parses input arguments and creates a new UntagCommand object
  */
-public class UntagCommandParser {
+public class UntagCommandParser implements Parser<UntagCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of the UntagCommand

--- a/src/test/java/seedu/address/logic/commands/TagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/TagCommandTest.java
@@ -36,10 +36,10 @@ public class TagCommandTest {
         ContactIndex index2 = new ContactIndex(2);
 
         TagCommand tag1 = new TagCommand(index1, moduleToAdd);
-        CommandResult result1 = tag1.execute(model);
+        tag1.execute(model);
         Person personToEdit1 = indexHandler.getPersonByIndex(index1).orElseThrow(() ->
                 new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX));
-        // "CS2105", "CS2104", "CS2103", "CS1010", "CHC5338", "BT2103"
+
         Set<ModuleTag> tags1 = new HashSet<>();
         tags1.add(new ModuleTag("CS2105"));
         tags1.add(new ModuleTag("CS2104"));
@@ -48,15 +48,13 @@ public class TagCommandTest {
         tags1.add(new ModuleTag("CHC5338"));
         tags1.add(new ModuleTag("BT2103"));
         tags1.add(new ModuleTag("CS1234"));
-        System.out.println(tags1);
-        System.out.println("hello");
         assertEquals(personToEdit1.getImmutableModuleTags().toString(), tags1.toString());
 
         TagCommand tag2 = new TagCommand(index2, modulesToAdd);
-        CommandResult result2 = tag2.execute(model);
+        tag2.execute(model);
         Person personToEdit2 = indexHandler.getPersonByIndex(index2).orElseThrow(() ->
                 new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX));
-        // "CS2108", "GEN2061", "CS2107", "DSA2102", "CS2102", "CS2106"
+
         Set<ModuleTag> tags2 = new HashSet<>();
         tags2.add(new ModuleTag("CS2108"));
         tags2.add(new ModuleTag("GEN2061"));
@@ -104,6 +102,6 @@ public class TagCommandTest {
         UntagCommand untag = new UntagCommand(null, modulesToAdd);
         untag.execute(model);
 
-    } // how do i checkstyle for test files
+    }
 
 }

--- a/src/test/java/seedu/address/logic/commands/TagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/TagCommandTest.java
@@ -1,0 +1,109 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.testutil.TypicalPersons.getTypicalEduMate;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.parser.IndexHandler;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.ContactIndex;
+import seedu.address.model.person.Person;
+import seedu.address.model.tag.ModuleTag;
+
+public class TagCommandTest {
+    private final Model model = new ModelManager(getTypicalEduMate(), new UserPrefs());
+    private final IndexHandler indexHandler = new IndexHandler(model);
+
+    @Test
+    public void execute_persons_correctTagsAdded() throws CommandException {
+
+        Set<ModuleTag> moduleToAdd = new HashSet<>();
+        moduleToAdd.add(new ModuleTag("CS1234"));
+
+        Set<ModuleTag> modulesToAdd = new HashSet<>();
+        modulesToAdd.add(new ModuleTag("CS1234"));
+        modulesToAdd.add(new ModuleTag("CS2345"));
+
+        ContactIndex index1 = new ContactIndex(1);
+        ContactIndex index2 = new ContactIndex(2);
+
+        TagCommand tag1 = new TagCommand(index1, moduleToAdd);
+        CommandResult result1 = tag1.execute(model);
+        Person personToEdit1 = indexHandler.getPersonByIndex(index1).orElseThrow(() ->
+                new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX));
+        // "CS2105", "CS2104", "CS2103", "CS1010", "CHC5338", "BT2103"
+        Set<ModuleTag> tags1 = new HashSet<>();
+        tags1.add(new ModuleTag("CS2105"));
+        tags1.add(new ModuleTag("CS2104"));
+        tags1.add(new ModuleTag("CS2103"));
+        tags1.add(new ModuleTag("CS1010"));
+        tags1.add(new ModuleTag("CHC5338"));
+        tags1.add(new ModuleTag("BT2103"));
+        tags1.add(new ModuleTag("CS1234"));
+        System.out.println(tags1);
+        System.out.println("hello");
+        assertEquals(personToEdit1.getImmutableModuleTags().toString(), tags1.toString());
+
+        TagCommand tag2 = new TagCommand(index2, modulesToAdd);
+        CommandResult result2 = tag2.execute(model);
+        Person personToEdit2 = indexHandler.getPersonByIndex(index2).orElseThrow(() ->
+                new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX));
+        // "CS2108", "GEN2061", "CS2107", "DSA2102", "CS2102", "CS2106"
+        Set<ModuleTag> tags2 = new HashSet<>();
+        tags2.add(new ModuleTag("CS2108"));
+        tags2.add(new ModuleTag("GEN2061"));
+        tags2.add(new ModuleTag("CS2107"));
+        tags2.add(new ModuleTag("DSA2102"));
+        tags2.add(new ModuleTag("CS2102"));
+        tags2.add(new ModuleTag("CS2106"));
+        tags2.add(new ModuleTag("CS1234"));
+        tags2.add(new ModuleTag("CS2345"));
+        assertEquals(personToEdit2.getImmutableModuleTags().toString(), tags2.toString());
+
+        UntagCommand untag1 = new UntagCommand(index1, moduleToAdd);
+        untag1.execute(model);
+
+        UntagCommand untag2 = new UntagCommand(index2, modulesToAdd);
+        untag2.execute(model);
+    }
+
+    @Test
+    public void execute_user_correctTagsAdded() throws CommandException {
+
+        Set<ModuleTag> modulesToAdd = new HashSet<>();
+        modulesToAdd.add(new ModuleTag("CS1234"));
+        modulesToAdd.add(new ModuleTag("CS2345"));
+
+        TagCommand userTest = new TagCommand(null, modulesToAdd);
+        userTest.execute(model);
+
+        Set<ModuleTag> tags = new HashSet<>() {{
+                add(new ModuleTag("CS2100"));
+                add(new ModuleTag("CS2101"));
+                add(new ModuleTag("CS2102"));
+                add(new ModuleTag("CS2103"));
+                add(new ModuleTag("CS2104"));
+                add(new ModuleTag("CS2105"));
+                add(new ModuleTag("CS2106"));
+                add(new ModuleTag("CS1234"));
+                add(new ModuleTag("CS2345"));
+            }};
+
+        Person userAct = model.getUser();
+
+        assertEquals(userAct.getImmutableModuleTags().toString(), tags.toString());
+
+        UntagCommand untag = new UntagCommand(null, modulesToAdd);
+        untag.execute(model);
+
+    } // how do i checkstyle for test files
+
+}

--- a/src/test/java/seedu/address/logic/commands/TagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/TagCommandTest.java
@@ -23,32 +23,12 @@ public class TagCommandTest {
     private final IndexHandler indexHandler = new IndexHandler(model);
 
     @Test
-    public void execute_persons_correctTagsAdded() throws CommandException {
-
-        Set<ModuleTag> moduleToAdd = new HashSet<>();
-        moduleToAdd.add(new ModuleTag("CS1234"));
-
+    public void execute_addTwoModulesToAng() throws CommandException {
         Set<ModuleTag> modulesToAdd = new HashSet<>();
         modulesToAdd.add(new ModuleTag("CS1234"));
         modulesToAdd.add(new ModuleTag("CS2345"));
 
-        ContactIndex index1 = new ContactIndex(1);
         ContactIndex index2 = new ContactIndex(2);
-
-        TagCommand tag1 = new TagCommand(index1, moduleToAdd);
-        tag1.execute(model);
-        Person personToEdit1 = indexHandler.getPersonByIndex(index1).orElseThrow(() ->
-                new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX));
-
-        Set<ModuleTag> tags1 = new HashSet<>();
-        tags1.add(new ModuleTag("CS2105"));
-        tags1.add(new ModuleTag("CS2104"));
-        tags1.add(new ModuleTag("CS2103"));
-        tags1.add(new ModuleTag("CS1010"));
-        tags1.add(new ModuleTag("CHC5338"));
-        tags1.add(new ModuleTag("BT2103"));
-        tags1.add(new ModuleTag("CS1234"));
-        assertEquals(personToEdit1.getImmutableModuleTags().toString(), tags1.toString());
 
         TagCommand tag2 = new TagCommand(index2, modulesToAdd);
         tag2.execute(model);
@@ -66,15 +46,38 @@ public class TagCommandTest {
         tags2.add(new ModuleTag("CS2345"));
         assertEquals(personToEdit2.getImmutableModuleTags().toString(), tags2.toString());
 
-        UntagCommand untag1 = new UntagCommand(index1, moduleToAdd);
-        untag1.execute(model);
-
         UntagCommand untag2 = new UntagCommand(index2, modulesToAdd);
         untag2.execute(model);
     }
 
     @Test
-    public void execute_user_correctTagsAdded() throws CommandException {
+    public void execute_addOneModuleToAlbert() throws CommandException {
+        Set<ModuleTag> moduleToAdd = new HashSet<>();
+        moduleToAdd.add(new ModuleTag("CS1234"));
+
+        ContactIndex index1 = new ContactIndex(1);
+
+        TagCommand tag1 = new TagCommand(index1, moduleToAdd);
+        tag1.execute(model);
+        Person personToEdit1 = indexHandler.getPersonByIndex(index1).orElseThrow(() ->
+                new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX));
+
+        Set<ModuleTag> tags1 = new HashSet<>();
+        tags1.add(new ModuleTag("CS2105"));
+        tags1.add(new ModuleTag("CS2104"));
+        tags1.add(new ModuleTag("CS2103"));
+        tags1.add(new ModuleTag("CS1010"));
+        tags1.add(new ModuleTag("CHC5338"));
+        tags1.add(new ModuleTag("BT2103"));
+        tags1.add(new ModuleTag("CS1234"));
+        assertEquals(personToEdit1.getImmutableModuleTags().toString(), tags1.toString());
+
+        UntagCommand untag1 = new UntagCommand(index1, moduleToAdd);
+        untag1.execute(model);
+    }
+
+    @Test
+    public void execute_addModulesToUser() throws CommandException {
 
         Set<ModuleTag> modulesToAdd = new HashSet<>();
         modulesToAdd.add(new ModuleTag("CS1234"));

--- a/src/test/java/seedu/address/logic/commands/UntagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UntagCommandTest.java
@@ -1,0 +1,72 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.testutil.TypicalPersons.getTypicalEduMate;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.parser.IndexHandler;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.ContactIndex;
+import seedu.address.model.person.Person;
+import seedu.address.model.tag.ModuleTag;
+
+public class UntagCommandTest {
+    private final Model model = new ModelManager(getTypicalEduMate(), new UserPrefs());
+    private final IndexHandler indexHandler = new IndexHandler(model);
+
+    @Test
+    public void execute_persons_correctTagsRemoved() throws CommandException {
+
+        Set<ModuleTag> moduleToRemove = new HashSet<>();
+        moduleToRemove.add(new ModuleTag("CS2105"));
+
+        Set<ModuleTag> modulesToRemove = new HashSet<>();
+        modulesToRemove.add(new ModuleTag("CS2108"));
+        modulesToRemove.add(new ModuleTag("GEN2061"));
+
+        ContactIndex index1 = new ContactIndex(1);
+        ContactIndex index2 = new ContactIndex(2);
+
+        UntagCommand untag1 = new UntagCommand(index1, moduleToRemove);
+        untag1.execute(model);
+        Person personToEdit1 = indexHandler.getPersonByIndex(index1).orElseThrow(() ->
+                new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX));
+
+        Set<ModuleTag> tags1 = new HashSet<>();
+        tags1.add(new ModuleTag("CS2104"));
+        tags1.add(new ModuleTag("CS2103"));
+        tags1.add(new ModuleTag("CS1010"));
+        tags1.add(new ModuleTag("CHC5338"));
+        tags1.add(new ModuleTag("BT2103"));
+
+        assertEquals(personToEdit1.getImmutableModuleTags().toString(), tags1.toString());
+
+        UntagCommand untag2 = new UntagCommand(index2, modulesToRemove);
+        untag2.execute(model);
+        Person personToEdit2 = indexHandler.getPersonByIndex(index2).orElseThrow(() ->
+                new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX));
+
+        Set<ModuleTag> tags2 = new HashSet<>();
+        tags2.add(new ModuleTag("CS2107"));
+        tags2.add(new ModuleTag("DSA2102"));
+        tags2.add(new ModuleTag("CS2102"));
+        tags2.add(new ModuleTag("CS2106"));
+
+        assertEquals(personToEdit2.getImmutableModuleTags().toString(), tags2.toString());
+
+        TagCommand tag1 = new TagCommand(index1, moduleToRemove);
+        tag1.execute(model);
+
+        TagCommand tag2 = new TagCommand(index2, modulesToRemove);
+        tag2.execute(model);
+
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/UntagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UntagCommandTest.java
@@ -23,17 +23,40 @@ public class UntagCommandTest {
     private final IndexHandler indexHandler = new IndexHandler(model);
 
     @Test
-    public void execute_persons_correctTagsRemoved() throws CommandException {
-
-        Set<ModuleTag> moduleToRemove = new HashSet<>();
-        moduleToRemove.add(new ModuleTag("CS2105"));
+    public void execute_removeModulesFromAng() throws CommandException {
 
         Set<ModuleTag> modulesToRemove = new HashSet<>();
         modulesToRemove.add(new ModuleTag("CS2108"));
         modulesToRemove.add(new ModuleTag("GEN2061"));
 
-        ContactIndex index1 = new ContactIndex(1);
         ContactIndex index2 = new ContactIndex(2);
+
+
+        UntagCommand untag2 = new UntagCommand(index2, modulesToRemove);
+        untag2.execute(model);
+        Person personToEdit2 = indexHandler.getPersonByIndex(index2).orElseThrow(() ->
+                new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX));
+
+        Set<ModuleTag> tags2 = new HashSet<>();
+        tags2.add(new ModuleTag("CS2107"));
+        tags2.add(new ModuleTag("DSA2102"));
+        tags2.add(new ModuleTag("CS2102"));
+        tags2.add(new ModuleTag("CS2106"));
+
+        assertEquals(personToEdit2.getImmutableModuleTags().toString(), tags2.toString());
+
+
+        TagCommand tag2 = new TagCommand(index2, modulesToRemove);
+        tag2.execute(model);
+
+    }
+
+    @Test
+    public void execute_removeModuleFromAlbert() throws CommandException {
+        Set<ModuleTag> moduleToRemove = new HashSet<>();
+        moduleToRemove.add(new ModuleTag("CS2105"));
+
+        ContactIndex index1 = new ContactIndex(1);
 
         UntagCommand untag1 = new UntagCommand(index1, moduleToRemove);
         untag1.execute(model);
@@ -49,24 +72,35 @@ public class UntagCommandTest {
 
         assertEquals(personToEdit1.getImmutableModuleTags().toString(), tags1.toString());
 
-        UntagCommand untag2 = new UntagCommand(index2, modulesToRemove);
-        untag2.execute(model);
-        Person personToEdit2 = indexHandler.getPersonByIndex(index2).orElseThrow(() ->
-                new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX));
-
-        Set<ModuleTag> tags2 = new HashSet<>();
-        tags2.add(new ModuleTag("CS2107"));
-        tags2.add(new ModuleTag("DSA2102"));
-        tags2.add(new ModuleTag("CS2102"));
-        tags2.add(new ModuleTag("CS2106"));
-
-        assertEquals(personToEdit2.getImmutableModuleTags().toString(), tags2.toString());
-
         TagCommand tag1 = new TagCommand(index1, moduleToRemove);
         tag1.execute(model);
+    }
 
-        TagCommand tag2 = new TagCommand(index2, modulesToRemove);
-        tag2.execute(model);
+    @Test
+    public void execute_removeModulesFromUser() throws CommandException {
+
+        Set<ModuleTag> modulesToRemove = new HashSet<>();
+        modulesToRemove.add(new ModuleTag("CS2100"));
+        modulesToRemove.add(new ModuleTag("CS2101"));
+
+        UntagCommand userTest = new UntagCommand(null, modulesToRemove);
+        userTest.execute(model);
+
+        Set<ModuleTag> tags = new HashSet<>() {{
+                add(new ModuleTag("CS2102"));
+                add(new ModuleTag("CS2103"));
+                add(new ModuleTag("CS2104"));
+                add(new ModuleTag("CS2105"));
+                add(new ModuleTag("CS2106"));
+            }};
+
+        Person userAct = model.getUser();
+
+        assertEquals(userAct.getImmutableModuleTags().toString(), tags.toString());
+
+        TagCommand tag = new TagCommand(null, modulesToRemove);
+        tag.execute(model);
 
     }
+
 }

--- a/src/test/java/seedu/address/logic/parser/TagCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/TagCommandParserTest.java
@@ -32,7 +32,7 @@ public class TagCommandParserTest {
 
     }
 
-    public void createValidArgsReturnsTagCommand(ContactIndex index, Set<ModuleTag> modules, String userInput) {
+    private void createValidArgsReturnsTagCommand(ContactIndex index, Set<ModuleTag> modules, String userInput) {
         TagCommand expectedTagCommand = new TagCommand(index, modules);
 
         assertParseSuccess(parser, userInput, expectedTagCommand);

--- a/src/test/java/seedu/address/logic/parser/TagCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/TagCommandParserTest.java
@@ -1,0 +1,43 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.TagCommand;
+import seedu.address.model.person.ContactIndex;
+import seedu.address.model.tag.ModuleTag;
+
+
+public class TagCommandParserTest {
+    private final TagCommandParser parser = new TagCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "   ", String.format(TagCommand.MESSAGE_NO_TAGS));
+    }
+
+    @Test
+    public void parse_validArgs_returnsTagCommand() {
+        createValidArgsReturnsTagCommand(
+                new ContactIndex(1),
+                new HashSet<ModuleTag>() {{
+                    add(new ModuleTag("CS1234"));
+                    }},
+                "1 m/CS1234");
+
+    }
+
+    public void createValidArgsReturnsTagCommand(ContactIndex index, Set<ModuleTag> modules, String userInput) {
+        TagCommand expectedTagCommand = new TagCommand(index, modules);
+
+        assertParseSuccess(parser, userInput, expectedTagCommand);
+    }
+
+
+
+}

--- a/src/test/java/seedu/address/logic/parser/UntagCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UntagCommandParserTest.java
@@ -30,7 +30,7 @@ public class UntagCommandParserTest {
                 "1 m/CS1234");
     }
 
-    public void createValidArgsReturnsUntagCommand(ContactIndex index, Set<ModuleTag> modules, String userInput) {
+    private void createValidArgsReturnsUntagCommand(ContactIndex index, Set<ModuleTag> modules, String userInput) {
         UntagCommand expectedUntagCommand = new UntagCommand(index, modules);
 
         assertParseSuccess(parser, userInput, expectedUntagCommand);

--- a/src/test/java/seedu/address/logic/parser/UntagCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UntagCommandParserTest.java
@@ -1,0 +1,38 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.UntagCommand;
+import seedu.address.model.person.ContactIndex;
+import seedu.address.model.tag.ModuleTag;
+
+public class UntagCommandParserTest {
+    private final UntagCommandParser parser = new UntagCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "   ", String.format(UntagCommand.MESSAGE_NO_TAGS));
+    }
+
+    @Test
+    public void parse_validArgs_returnsUntagCommand() {
+        createValidArgsReturnsUntagCommand(
+                new ContactIndex(1),
+                new HashSet<ModuleTag>() {{
+                    add(new ModuleTag("CS1234"));
+                    }},
+                "1 m/CS1234");
+    }
+
+    public void createValidArgsReturnsUntagCommand(ContactIndex index, Set<ModuleTag> modules, String userInput) {
+        UntagCommand expectedUntagCommand = new UntagCommand(index, modules);
+
+        assertParseSuccess(parser, userInput, expectedUntagCommand);
+    }
+}


### PR DESCRIPTION
Creates a skeleton for test cases.
To be added on when adding tag group functionality.

Able to close #41 

But in doing so we can raise another issue to cover more for tests.