### PR TITLE
Set Contact Index as Default Comparator for Sort

### DIFF
--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -47,15 +47,7 @@ public class SortCommandParser implements Parser<SortCommand> {
     @Override
     public SortCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        if (args.trim().equals("index")) {
-            Comparator<Person> indexComparator = new Comparator<Person>() {
-                @Override
-                public int compare(Person o1, Person o2) {
-                    return o1.getContactIndex().compareTo(o2.getContactIndex());
-                }
-            };
-            return new SortCommand(indexComparator, "Reverting to original index!");
-        }
+
         // the prefix positions are ordered from first to last
         // the argument multimap gives an unordered list so we cannot use it here
         List<PrefixPosition> prefixPositions = ArgumentTokenizer
@@ -77,9 +69,10 @@ public class SortCommandParser implements Parser<SortCommand> {
 
         // processes comparators from first to last (first goes first)
         // creates one chained comparator
+        // Default comparator is contact index
         Comparator<Person> comparator = CollectionUtil
                 .zip(comparatorStream, isAscendingStream, this::reverseComparatorIfDescending)
-                .reduce(Comparator.comparing(Person::getName), this::combineComparators);
+                .reduce(Comparator.comparing(Person::getContactIndex), this::combineComparators);
 
         // converts the prefixes into their name descriptors
         // n/ -> Name for example

--- a/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
@@ -93,7 +93,7 @@ public class SortCommandParserTest {
         List<ContactIndex> sortedIndexSorted = personList.stream()
                 .map(x -> x.getContactIndex()).collect(Collectors.toUnmodifiableList());
         assertNotEquals(contactIndexSortedByName.toArray(), sortedIndexSorted.toArray());
-        parser.parse(" index").execute(model);
+        parser.parse("").execute(model);
         List<ContactIndex> indexStream = personList.stream()
                 .map(x -> x.getContactIndex()).collect(Collectors.toUnmodifiableList());
         assertArrayEquals(sortedIndexSorted.toArray(), indexStream.toArray());


### PR DESCRIPTION
Don't need to merge if you don't agree with it.

But `sort` will now sort by ascending index. That's pretty much it.

Closes #135 