### PR TITLE
Add checks for empty arguments for Tag and Untag

### DIFF
--- a/docs/team/kennycjy.md
+++ b/docs/team/kennycjy.md
@@ -12,13 +12,16 @@ Given below are my contributions to the project.
 * **Code contributed**: [RepoSense link](https://nus-cs2103-ay2223s2.github.io/tp-dashboard/?search=kennycjy&breakdown=true)
 
 * **Enhancements to existing features**:
-    * To be added.
+    * Implemented the `Tag` and `Untag` commands.
+    * Drafted the first modifications to `ModuleTag` and `Tag` commands to implement `Lessons`
+    * Modify `Tag` and `Untag` to work with `GroupTag` and not just `ModuleTag`
 
 * **Documentation**:
     * User Guide:
         * Pushed the first version of the User Guide that is drafted by the whole team.
+        * Updated the user guide for areas pertaining to `Tag` and `Untag`
     * Developer Guide:
-        * To be added.
+        * Updated the developer guide for areas pertaining to `Tag` and `Untag`
 
 * **Community**:
     * To be added

--- a/src/main/java/seedu/address/logic/parser/TagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/TagCommandParser.java
@@ -49,9 +49,18 @@ public class TagCommandParser implements Parser<TagCommand> {
         }
 
         if (groupsToAdd.isPresent()) {
-            return new TagCommand(contactIndex, groupsToAdd.get(), TagType.GROUP);
+            Set<GroupTag> groups = groupsToAdd.get();
+            if (groups.isEmpty()) {
+                throw new ParseException(TagCommand.MESSAGE_NO_TAGS);
+            }
+            return new TagCommand(contactIndex, groups, TagType.GROUP);
         }
 
-        return new TagCommand(contactIndex, modulesToAdd.get(), TagType.MODULE);
+        Set<ModuleTag> modules = modulesToAdd.get();
+        if (modules.isEmpty()) {
+            throw new ParseException(TagCommand.MESSAGE_NO_TAGS);
+        }
+
+        return new TagCommand(contactIndex, modules, TagType.MODULE);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/UntagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UntagCommandParser.java
@@ -48,10 +48,18 @@ public class UntagCommandParser implements Parser<UntagCommand> {
         }
 
         if (groupsToRemove.isPresent()) {
-            return new UntagCommand(contactIndex, groupsToRemove.get(), TagType.GROUP);
+            Set<GroupTag> groups = groupsToRemove.get();
+            if (groups.isEmpty()) {
+                throw new ParseException((UntagCommand.MESSAGE_NO_TAGS));
+            }
+            return new UntagCommand(contactIndex, groups, TagType.GROUP);
         }
 
-        return new UntagCommand(contactIndex, modulesToRemove.get(), TagType.MODULE);
+        Set<ModuleTag> modules = modulesToRemove.get();
+        if (modules.isEmpty()) {
+            throw new ParseException((UntagCommand.MESSAGE_NO_TAGS));
+        }
+        return new UntagCommand(contactIndex, modules, TagType.MODULE);
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/TagCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/TagCommandParserTest.java
@@ -25,6 +25,14 @@ public class TagCommandParserTest {
     }
 
     @Test
+    public void parse_emptyArgWithPrefix_throwsParseException() {
+        assertParseFailure(parser, "1 g/", String.format(TagCommand.MESSAGE_NO_TAGS));
+        assertParseFailure(parser, " g/", String.format(TagCommand.MESSAGE_NO_TAGS));
+        assertParseFailure(parser, "1 m/", String.format(TagCommand.MESSAGE_NO_TAGS));
+        assertParseFailure(parser, " m/", String.format(TagCommand.MESSAGE_NO_TAGS));
+    }
+
+    @Test
     public void parse_validArgs_returnsTagCommand() {
         createModuleValidArgsReturnsTagCommand(
                 new ContactIndex(1),

--- a/src/test/java/seedu/address/logic/parser/TagCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/TagCommandParserTest.java
@@ -41,12 +41,28 @@ public class TagCommandParserTest {
                     }},
                 "1 m/CS1234");
 
+        createModuleValidArgsReturnsTagCommand(
+                new ContactIndex(3),
+                new HashSet<ModuleTag>() {{
+                    add(new ModuleTag("CS1234"));
+                    add(new ModuleTag("CS2345"));
+                }},
+                "3 m/CS1234 m/CS2345");
+
         createGroupValidArgsReturnsTagCommand(
                 new ContactIndex(2),
                 new HashSet<GroupTag>() {{
                     add(new GroupTag("Enemy"));
                 }},
                 "2 g/Enemy");
+
+        createGroupValidArgsReturnsTagCommand(
+                new ContactIndex(4),
+                new HashSet<GroupTag>() {{
+                    add(new GroupTag("Bro"));
+                    add(new GroupTag("Family"));
+                }},
+                "4 g/Bro g/Family");
     }
 
     @Test
@@ -57,7 +73,10 @@ public class TagCommandParserTest {
     @Test
     public void parse_bothTagsInputted_throwsParseException() {
         assertThrows(ParseException.class, () -> parser.parse("m/CS2100 g/TA"));
+        assertParseFailure(parser, " m/ g/", String.format(TagCommand.MESSAGE_BOTH_TAGS_INPUTTED));
     }
+
+
 
     private void createModuleValidArgsReturnsTagCommand(ContactIndex index, Set<ModuleTag> modules, String userInput) {
         TagCommand expectedTagCommand = new TagCommand(index, modules, TagType.MODULE);

--- a/src/test/java/seedu/address/logic/parser/UntagCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UntagCommandParserTest.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.Assert.assertThrows;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -9,6 +10,7 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.UntagCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.ContactIndex;
 import seedu.address.model.tag.GroupTag;
 import seedu.address.model.tag.ModuleTag;
@@ -37,12 +39,34 @@ public class UntagCommandParserTest {
                     add(new ModuleTag("CS1234"));
                     }},
                 "1 m/CS1234");
+
+        createModuleValidArgsReturnsUntagCommand(
+                new ContactIndex(3),
+                new HashSet<ModuleTag>() {{
+                    add(new ModuleTag("CS2345"));
+                    add(new ModuleTag("CS3456"));
+                }},
+                "3 m/CS2345 m/CS3456");
         createGroupValidArgsReturnsUntagCommand(
                 new ContactIndex(2),
                 new HashSet<GroupTag>() {{
                     add(new GroupTag("Friend"));
                 }},
                 "2 g/Friend");
+
+        createGroupValidArgsReturnsUntagCommand(
+                new ContactIndex(4),
+                new HashSet<GroupTag>() {{
+                    add(new GroupTag("Controller"));
+                    add(new GroupTag("Mouse"));
+                }},
+                "4 g/Controller g/Mouse");
+    }
+
+    @Test
+    public void parse_bothTagsInputted_throwsParseException() {
+        assertThrows(ParseException.class, () -> parser.parse("m/CS2100 g/TA"));
+        assertParseFailure(parser, " m/ g/", String.format(UntagCommand.MESSAGE_BOTH_TAGS_INPUTTED));
     }
 
     private void createModuleValidArgsReturnsUntagCommand(ContactIndex index, Set<ModuleTag> modules,

--- a/src/test/java/seedu/address/logic/parser/UntagCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UntagCommandParserTest.java
@@ -22,6 +22,14 @@ public class UntagCommandParserTest {
     }
 
     @Test
+    public void parse_emptyArgWithPrefix_throwsParseException() {
+        assertParseFailure(parser, "1 g/", String.format(UntagCommand.MESSAGE_NO_TAGS));
+        assertParseFailure(parser, " g/", String.format(UntagCommand.MESSAGE_NO_TAGS));
+        assertParseFailure(parser, "1 m/", String.format(UntagCommand.MESSAGE_NO_TAGS));
+        assertParseFailure(parser, " m/", String.format(UntagCommand.MESSAGE_NO_TAGS));
+    }
+
+    @Test
     public void parse_validArgs_returnsUntagCommand() {
         createModuleValidArgsReturnsUntagCommand(
                 new ContactIndex(1),


### PR DESCRIPTION
Fixes #258 

Simple checks inserted to see if the `Set` of `GroupTag` or `ModuleTag` are empty.

Also added tests for exceptions thrown.