### PR TITLE
Elaborate on Sort Command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -964,6 +964,18 @@ By simply typing `sort` followed by the relevant criteria, you can sort your con
 
 </div>
 
+<br>
+
+<div markdown="block" class="alert alert-info">
+
+:bulb: **Accepted versions for sort order**: <br>
+In short, in the command formats `z/a` and `z/d`, we only care about the **first letter** immediately after the slash. It can be either in upper case or lower case and can have anything behind it. For example, `z/ascending` and `z/Disco` would both work. <br><br>
+
+However, if the first letter is not either `a`, `d`, `D` or `A`, then we use the **default ordering**.
+
+</div>
+<br>
+
 We will now teach you how to effectively use the `sort` command.
 
 <div markdown="block" class="alert alert-info">

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -968,7 +968,7 @@ By simply typing `sort` followed by the relevant criteria, you can sort your con
 
 <div markdown="block" class="alert alert-info">
 
-:bulb: **Accepted versions for sort order**: <br>
+:bulb: **Accepted versions for `sort` order**: <br>
 In short, in the command formats `z/a` and `z/d`, we only care about the **first letter** immediately after the slash. It can be either in upper case or lower case and can have anything behind it. For example, `z/ascending` and `z/Disco` would both work. <br><br>
 
 However, if the first letter is not either `a`, `d`, `D` or `A`, then we use the **default ordering**.


### PR DESCRIPTION
https://mynameizzhafeez.github.io/tp/UserGuide.html

<div markdown="block" class="alert alert-info">

:bulb: **Accepted versions for sort order**: <br>
In short, in the command formats `z/a` and `z/d`, we only care about the **first letter** immediately after the slash. It can be either in upper case or lower case and can have anything behind it. For example, `z/ascending` and `z/Disco` would both work. <br><br>

However, if the first letter is not either `a`, `d`, `D` or `A`, then we use the **default ordering**.

</div>
<br>